### PR TITLE
Add BTC Fear and Greed dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,71 @@
-=???
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bitcoin Fear & Greed Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/cerulean/bootstrap.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">BTC Dashboard</a>
+    </div>
+  </nav>
+
+  <div class="container">
+    <h1 class="mb-4">Índice de Miedo y Codicia</h1>
+    <div class="card mb-4">
+      <div class="card-body">
+        <h4 class="card-title">Valor actual: <span id="current-value">Cargando...</span></h4>
+        <p class="card-text" id="current-classification"></p>
+      </div>
+    </div>
+    <canvas id="fngChart" height="100"></canvas>
+  </div>
+
+  <script>
+    async function fetchData() {
+      const res = await fetch('https://api.alternative.me/fng/?limit=30');
+      const json = await res.json();
+      const entries = json.data.reverse();
+
+      const labels = entries.map(e => {
+        const d = new Date(e.timestamp * 1000);
+        return d.toISOString().split('T')[0];
+      });
+      const values = entries.map(e => Number(e.value));
+
+      const ctx = document.getElementById('fngChart').getContext('2d');
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Índice',
+            data: values,
+            fill: false,
+            borderColor: '#007bff',
+            tension: 0.1
+          }]
+        },
+        options: {
+          scales: {
+            y: {
+              beginAtZero: true,
+              max: 100
+            }
+          }
+        }
+      });
+
+      const latest = entries[entries.length - 1];
+      document.getElementById('current-value').textContent = latest.value;
+      document.getElementById('current-classification').textContent = 'Clasificación: ' + latest.value_classification;
+    }
+
+    fetchData();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a HTML page with a Cerulean Bootstrap theme
- show the Bitcoin Fear & Greed Index using Chart.js

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68496b216528832f8a248f2428428062