### PR TITLE
Improve dashboard with BTC/FNG chart and RAY news

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,69 +3,140 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bitcoin Fear & Greed Dashboard</title>
+  <title>BTC Dashboard</title>
   <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/cerulean/bootstrap.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+  <style>
+    .news-container { max-height: 300px; overflow-y: scroll; }
+  </style>
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
-    <div class="container-fluid">
-      <a class="navbar-brand" href="#">BTC Dashboard</a>
-    </div>
-  </nav>
-
   <div class="container">
-    <h1 class="mb-4">Índice de Miedo y Codicia</h1>
-    <div class="card mb-4">
-      <div class="card-body">
-        <h4 class="card-title">Valor actual: <span id="current-value">Cargando...</span></h4>
-        <p class="card-text" id="current-classification"></p>
+    <header class="text-center my-4">
+      <h1>El grupo de los próximos clase media</h1>
+      <p class="text-muted">Invertir es tu responsabilidad</p>
+    </header>
+
+    <section class="mb-5">
+      <h2 class="h4">BTC Price vs Fear &amp; Greed Index</h2>
+      <canvas id="btcFngChart" height="100"></canvas>
+    </section>
+
+    <section class="mb-5">
+      <h2 class="h4">BTC vs ETH</h2>
+      <canvas id="btcEthChart" height="100"></canvas>
+    </section>
+
+    <section class="mb-5">
+      <h2 class="h4">Noticias sobre RAY</h2>
+      <div class="news-container">
+        <ul id="news-list" class="list-group"></ul>
       </div>
-    </div>
-    <canvas id="fngChart" height="100"></canvas>
+    </section>
   </div>
 
-  <script>
-    async function fetchData() {
-      const res = await fetch('https://api.alternative.me/fng/?limit=30');
-      const json = await res.json();
-      const entries = json.data.reverse();
+<script>
+async function fetchBtcAndFng() {
+  const [fngRes, btcRes] = await Promise.all([
+    fetch('https://api.alternative.me/fng/?limit=30'),
+    fetch('https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=30&interval=daily')
+  ]);
+  const fngJson = await fngRes.json();
+  const btcJson = await btcRes.json();
+  const fngData = fngJson.data.reverse();
+  const btcPrices = btcJson.prices;
 
-      const labels = entries.map(e => {
-        const d = new Date(e.timestamp * 1000);
-        return d.toISOString().split('T')[0];
-      });
-      const values = entries.map(e => Number(e.value));
+  const labels = fngData.map((e,i) => {
+    const d = new Date(e.timestamp * 1000);
+    return d.toISOString().split('T')[0];
+  });
+  const fngValues = fngData.map(e => Number(e.value));
+  const btcValues = btcPrices.map(p => p[1]);
+  const bgColors = fngValues.map(v => v > 50 ? 'rgba(0,200,0,0.6)' : 'rgba(200,0,0,0.6)');
 
-      const ctx = document.getElementById('fngChart').getContext('2d');
-      new Chart(ctx, {
-        type: 'line',
-        data: {
-          labels: labels,
-          datasets: [{
-            label: 'Índice',
-            data: values,
-            fill: false,
-            borderColor: '#007bff',
-            tension: 0.1
-          }]
+  const ctx = document.getElementById('btcFngChart').getContext('2d');
+  new Chart(ctx, {
+    data: {
+      labels: labels,
+      datasets: [
+        {
+          type: 'line',
+          label: 'BTC Precio (USD)',
+          data: btcValues,
+          borderColor: '#ff9900',
+          yAxisID: 'y1',
+          tension: 0.1,
+          fill: false
         },
-        options: {
-          scales: {
-            y: {
-              beginAtZero: true,
-              max: 100
-            }
-          }
+        {
+          type: 'bar',
+          label: 'Fear & Greed',
+          data: fngValues,
+          backgroundColor: bgColors,
+          yAxisID: 'y2'
         }
-      });
-
-      const latest = entries[entries.length - 1];
-      document.getElementById('current-value').textContent = latest.value;
-      document.getElementById('current-classification').textContent = 'Clasificación: ' + latest.value_classification;
+      ]
+    },
+    options: {
+      scales: {
+        y1: { type: 'linear', position: 'left', title: { display: true, text: 'Precio USD' } },
+        y2: { type: 'linear', position: 'right', min: 0, max: 100, title: { display: true, text: 'F&G' }, grid: { drawOnChartArea: false } }
+      }
     }
+  });
+}
 
-    fetchData();
-  </script>
+async function fetchBtcVsEth() {
+  const [btcRes, ethRes] = await Promise.all([
+    fetch('https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=30&interval=daily'),
+    fetch('https://api.coingecko.com/api/v3/coins/ethereum/market_chart?vs_currency=usd&days=30&interval=daily')
+  ]);
+  const btcJson = await btcRes.json();
+  const ethJson = await ethRes.json();
+  const labels = btcJson.prices.map(p => new Date(p[0]).toISOString().split('T')[0]);
+  const btcPrices = btcJson.prices.map(p => p[1]);
+  const ethPrices = ethJson.prices.map(p => p[1]);
+
+  const ctx = document.getElementById('btcEthChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: labels,
+      datasets: [
+        { label: 'BTC', data: btcPrices, borderColor: '#f2a900', fill: false, tension: 0.1 },
+        { label: 'ETH', data: ethPrices, borderColor: '#627eea', fill: false, tension: 0.1 }
+      ]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: false }
+      }
+    }
+  });
+}
+
+async function fetchRayNews() {
+  const res = await fetch('https://www.reddit.com/r/raydium/new.json?limit=10');
+  const json = await res.json();
+  const posts = json.data.children;
+  const list = document.getElementById('news-list');
+  list.innerHTML = '';
+  posts.forEach(p => {
+    const li = document.createElement('li');
+    li.className = 'list-group-item';
+    const a = document.createElement('a');
+    a.href = 'https://www.reddit.com' + p.data.permalink;
+    a.textContent = p.data.title;
+    a.target = '_blank';
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+}
+
+fetchBtcAndFng();
+fetchBtcVsEth();
+fetchRayNews();
+setInterval(fetchRayNews, 60000);
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make page more professional with new header and tagline
- add BTC price vs Fear & Greed index dual‑axis chart
- include BTC vs ETH comparison chart
- show scrolling news about RAY from Reddit

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849870056dc832fbfa791ab49a9bd3a