### PR TITLE
Switch ray news feed and embed ETH/BTC widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>BTC Dashboard</title>
   <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/cerulean/bootstrap.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+  <script src="https://s3.tradingview.com/tv.js"></script>
   <style>
     .news-container { max-height: 300px; overflow-y: scroll; }
   </style>
@@ -17,22 +18,34 @@
       <p class="text-muted">Invertir es tu responsabilidad</p>
     </header>
 
-    <section class="mb-5">
-      <h2 class="h4">BTC Price vs Fear &amp; Greed Index</h2>
-      <canvas id="btcFngChart" height="100"></canvas>
-    </section>
-
-    <section class="mb-5">
-      <h2 class="h4">BTC vs ETH</h2>
-      <canvas id="btcEthChart" height="100"></canvas>
-    </section>
-
-    <section class="mb-5">
-      <h2 class="h4">Noticias sobre RAY</h2>
-      <div class="news-container">
-        <ul id="news-list" class="list-group"></ul>
+    <div class="row my-4">
+      <div class="col">
+        <div class="card p-3">
+          <h2 class="h4">BTC Price vs Fear &amp; Greed Index</h2>
+          <canvas id="btcFngChart" height="100"></canvas>
+        </div>
       </div>
-    </section>
+    </div>
+
+    <div class="row my-4">
+      <div class="col">
+        <div class="card p-3">
+          <h2 class="h4">ETH/BTC</h2>
+          <div id="ethbtc-chart"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row my-4">
+      <div class="col">
+        <div class="card p-3">
+          <h2 class="h4">Noticias sobre RAY</h2>
+          <div class="news-container">
+            <ul id="news-list" class="list-group"></ul>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 
 <script>
@@ -116,27 +129,48 @@ async function fetchBtcVsEth() {
 }
 
 async function fetchRayNews() {
-  const res = await fetch('https://www.reddit.com/r/raydium/new.json?limit=10');
-  const json = await res.json();
-  const posts = json.data.children;
-  const list = document.getElementById('news-list');
-  list.innerHTML = '';
-  posts.forEach(p => {
-    const li = document.createElement('li');
-    li.className = 'list-group-item';
-    const a = document.createElement('a');
-    a.href = 'https://www.reddit.com' + p.data.permalink;
-    a.textContent = p.data.title;
-    a.target = '_blank';
-    li.appendChild(a);
-    list.appendChild(li);
-  });
+  try {
+    const res = await fetch('https://www.reddit.com/r/raydium/.rss');
+    if (!res.ok) throw new Error('Request failed');
+    const xmlText = await res.text();
+    const parser = new DOMParser();
+    const xml = parser.parseFromString(xmlText, 'application/xml');
+    const entries = Array.from(xml.querySelectorAll('entry')).slice(0, 10);
+    const list = document.getElementById('news-list');
+    list.innerHTML = '';
+    entries.forEach(item => {
+      const title = item.querySelector('title')?.textContent || 'Sin título';
+      const link = item.querySelector('link')?.getAttribute('href');
+      const li = document.createElement('li');
+      li.className = 'list-group-item';
+      const a = document.createElement('a');
+      a.href = link;
+      a.textContent = title;
+      a.target = '_blank';
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+  } catch (err) {
+    const list = document.getElementById('news-list');
+    list.innerHTML = '<li class="list-group-item text-danger">No se pudo cargar el feed</li>';
+  }
 }
 
+new TradingView.widget({
+  container_id: 'ethbtc-chart',
+  symbol: 'BINANCE:ETHBTC',
+  autosize: true,
+  theme: 'light',
+  hide_top_toolbar: true,
+  hide_legend: true,
+  style: 1,
+  locale: 'en'
+});
+
 fetchBtcAndFng();
-fetchBtcVsEth();
+// fetchBtcVsEth();
 fetchRayNews();
-setInterval(fetchRayNews, 60000);
+setInterval(fetchRayNews, 300000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed TradingView ETH/BTC mini chart instead of custom Chart.js chart
- fetch Raydium news from the subreddit RSS feed and handle errors
- improve layout using Bootswatch cards and grid

## Testing
- `python3 -m http.server 8000` *(served page locally)*

------
https://chatgpt.com/codex/tasks/task_e_68498b2fcd04832fa2fdc28754b4d02d