### PR TITLE
Integrate TradingView widget for ETHBTC

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,18 @@
       <div class="col">
         <div class="card p-3">
           <h2 class="h4">ETH/BTC</h2>
-          <canvas id="btcEthChart" height="300"></canvas>
+          <div class="tradingview-widget-container" style="height:300px;">
+            <div id="tradingview_ethbtc" style="height:100%;"></div>
+            <script type="text/javascript" src="https://s3.tradingview.com/tv.js"></script>
+            <script type="text/javascript">
+              new TradingView.widget({
+                "autosize": true,
+                "symbol": "BINANCE:ETHBTC",
+                "interval": "D",
+                "container_id": "tradingview_ethbtc"
+              });
+            </script>
+          </div>
         </div>
       </div>
     </div>
@@ -99,34 +110,6 @@ async function fetchBtcAndFng() {
   });
 }
 
-async function fetchBtcVsEth() {
-  const [btcRes, ethRes] = await Promise.all([
-    fetch('https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=30&interval=daily'),
-    fetch('https://api.coingecko.com/api/v3/coins/ethereum/market_chart?vs_currency=usd&days=30&interval=daily')
-  ]);
-  const btcJson = await btcRes.json();
-  const ethJson = await ethRes.json();
-  const labels = btcJson.prices.map(p => new Date(p[0]).toISOString().split('T')[0]);
-  const btcPrices = btcJson.prices.map(p => p[1]);
-  const ethPrices = ethJson.prices.map(p => p[1]);
-
-  const ctx = document.getElementById('btcEthChart').getContext('2d');
-  new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: labels,
-      datasets: [
-        { label: 'BTC', data: btcPrices, borderColor: '#f2a900', fill: false, tension: 0.1 },
-        { label: 'ETH', data: ethPrices, borderColor: '#627eea', fill: false, tension: 0.1 }
-      ]
-    },
-    options: {
-      scales: {
-        y: { beginAtZero: false }
-      }
-    }
-  });
-}
 
 async function fetchRayNews() {
   try {
@@ -158,7 +141,6 @@ async function fetchRayNews() {
 
 
 fetchBtcAndFng();
-fetchBtcVsEth();
 fetchRayNews();
 setInterval(fetchRayNews, 300000);
 </script>


### PR DESCRIPTION
## Summary
- replace the ETH/BTC canvas with TradingView's widget iframe
- remove the unused Chart.js ETH/BTC chart implementation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684995da8f40832fb09b0cc902739fad