### PR TITLE
Add asset extraction script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ This project contains a small dashboard (`index.html`) that displays Bitcoin pri
    ```bash
    npm install
    ```
-2. Serve the page (for example with Python) and open it in your browser:
+2. Decode the asset files:
+   ```bash
+   npm run extract-assets
+   ```
+3. Serve the page (for example with Python) and open it in your browser:
    ```bash
    python -m http.server
    # then visit http://localhost:8000/index.html

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "proyecto-bitcoin",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "extract-assets": "node scripts/extract_assets.js"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/scripts/extract_assets.js
+++ b/scripts/extract_assets.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const assetsDir = path.join(__dirname, '..', 'assets');
+
+if (!fs.existsSync(assetsDir)) {
+  console.error('Assets directory not found:', assetsDir);
+  process.exit(1);
+}
+
+for (const file of fs.readdirSync(assetsDir)) {
+  if (file.endsWith('.txt')) {
+    const inputPath = path.join(assetsDir, file);
+    const outputName = file.replace(/\.txt$/, '');
+    const outputPath = path.join(assetsDir, outputName);
+    const base64 = fs.readFileSync(inputPath, 'utf8').trim();
+    const buffer = Buffer.from(base64, 'base64');
+    fs.writeFileSync(outputPath, buffer);
+    console.log('Decoded', outputName);
+  }
+}


### PR DESCRIPTION
## Summary
- decode base64 images in `assets` by running a new script
- document asset extraction step

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849a5a68334832f8e8cc8f39aec5d0c