### PR TITLE
Handle binary assets via script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+assets/img/*.png
+assets/img/*.jpg

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ This project contains a small dashboard (`index.html`) that displays Bitcoin pri
    ```bash
    npm install
    ```
-2. Serve the page (for example with Python) and open it in your browser:
+2. Generate the image assets (not tracked in git):
+   ```bash
+   node scripts/extract_assets.js
+   ```
+3. Serve the page (for example with Python) and open it in your browser:
    ```bash
    python -m http.server
    # then visit http://localhost:8000/index.html

--- a/scripts/extract_assets.js
+++ b/scripts/extract_assets.js
@@ -1,0 +1,16 @@
+import { mkdir, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dirname, '..', 'assets', 'img');
+
+await mkdir(outDir, { recursive: true });
+
+const logoBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==';
+const heroBase64 = '/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=';
+
+await writeFile(join(outDir, 'logo.png'), Buffer.from(logoBase64, 'base64'));
+await writeFile(join(outDir, 'hero-bg.jpg'), Buffer.from(heroBase64, 'base64'));
+
+console.log(`Assets extracted to ${outDir}`);


### PR DESCRIPTION
## Summary
- ignore `assets/img` png and jpg files
- add a script to regenerate `logo.png` and `hero-bg.jpg`
- document asset extraction in README

## Testing
- `npm install`
- `npm test`
- `node scripts/extract_assets.js`

------
https://chatgpt.com/codex/tasks/task_e_6849a59602b0832f98be75e1659c139c