### PR TITLE
Ensure google news list refresh is delayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ The dashboard uses several public APIs. You can change them inside `src/dashboar
 - **Bitcoin prices**: `https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=30&interval=daily`
 - **News feed**: `https://api.rss2json.com/v1/api.json?rss_url=https://news.google.com/rss/search?q=bitcoin`
 
+The news section pulls headlines from Google News using the rss2json service.
+It refreshes automatically every five minutes to show the latest articles.
+
 ## Adding images
 
 Place your images in the `assets/img/` directory and reference them from HTML or CSS using a relative path, e.g. `assets/img/my-photo.jpg`.

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -105,16 +105,16 @@ export function initTradingView() {
   });
 }
 
-// Initialize when DOM is ready
-if (document.readyState !== 'loading') {
+function initDashboard() {
   fetchBtcAndFng();
   fetchGoogleNews();
   initTradingView();
-} else {
-  document.addEventListener('DOMContentLoaded', () => {
-    fetchBtcAndFng();
-    fetchGoogleNews();
-    initTradingView();
-  });
+  setInterval(fetchGoogleNews, 300000);
 }
-setInterval(fetchGoogleNews, 300000);
+
+// Initialize when DOM is ready
+if (document.readyState !== 'loading') {
+  initDashboard();
+} else {
+  document.addEventListener('DOMContentLoaded', initDashboard);
+}


### PR DESCRIPTION
## Summary
- add `initDashboard` so periodic refresh starts after DOM is ready
- mention Google News RSS refresh in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849b7af506c832fa2c72455e657d2c4