### PR TITLE
Switch to chartjs-gauge-v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm test
 - **Bootswatch** (Cerulean theme) [`bootswatch@5.3.2`](https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/cerulean/bootstrap.min.css)
 - **Bootstrap JS** [`bootstrap@5.3.2`](https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js)
 - **Chart.js** [`chart.js@3.9.1`](https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js)
-- **chartjs-gauge** [`chartjs-gauge@0.3.0`](https://cdn.jsdelivr.net/npm/chartjs-gauge@0.3.0/dist/chartjs-gauge.min.js)
+- **chartjs-gauge-v3** [`chartjs-gauge-v3@3.0.0`](https://cdn.jsdelivr.net/npm/chartjs-gauge-v3@3.0.0/dist/chartjs-gauge.min.js)
 
 The gauge showing the Fear & Greed index relies on this plugin and is loaded automatically from the CDN when you open `index.html`.
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/cerulean/bootstrap.min.css">
   <link rel="stylesheet" href="assets/style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chartjs-gauge@0.3.0/dist/chartjs-gauge.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-gauge-v3@3.0.0/dist/chartjs-gauge.min.js"></script>
 </head>
 <body>
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary">

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "proyecto-bitcoin",
       "dependencies": {
-        "chartjs-gauge": "^0.3.0"
+        "chartjs-gauge-v3": "^3.0.0"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -1771,55 +1771,19 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
-      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.1.tgz",
+      "integrity": "sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==",
       "license": "MIT",
-      "dependencies": {
-        "chartjs-color": "^2.1.0",
-        "moment": "^2.10.2"
-      }
+      "peer": true
     },
-    "node_modules/chartjs-color": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
-      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
-      "license": "MIT",
-      "dependencies": {
-        "chartjs-color-string": "^0.6.0",
-        "color-convert": "^1.9.3"
-      }
-    },
-    "node_modules/chartjs-color-string": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
-      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0"
-      }
-    },
-    "node_modules/chartjs-color/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/chartjs-color/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/chartjs-gauge": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/chartjs-gauge/-/chartjs-gauge-0.3.0.tgz",
-      "integrity": "sha512-/R5N4Q/N3GobAuU+jVli72FAX7rYy7N6I166ZYNyW3KzkRVqMls1qjuPmcbHXmL5XffNvp6kSZ13C5TmT7lJIQ==",
-      "dependencies": {
-        "chart.js": "^2.8.0"
+    "node_modules/chartjs-gauge-v3": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-gauge-v3/-/chartjs-gauge-v3-3.0.0.tgz",
+      "integrity": "sha512-7EyKFfbMg5cYs4+h5pZW/gKJpiVMEa+7uPGrBaMZUw9rOqgORnK5VU2A7m08iYPA+uZhniLwltpe20Mhlb/lTQ==",
+      "license": "MIT*",
+      "peerDependencies": {
+        "chart.js": "^3.9.1"
       }
     },
     "node_modules/ci-info": {
@@ -1895,6 +1859,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -3683,15 +3648,6 @@
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
       "engines": {
         "node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "testEnvironment": "jsdom"
   },
   "dependencies": {
-    "chartjs-gauge": "^0.3.0"
+    "chartjs-gauge-v3": "^3.0.0"
   }
 }

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -52,7 +52,7 @@ export async function fetchBtcAndFng() {
       },
       options: {
         responsive: true,
-        needle: { radiusPercentage: 2, widthPercentage: 3.2, lengthPercentage: 80 },
+        needle: { radius: '2%', width: '3.2%', length: '80%' },
         valueLabel: { display: true }
       }
     });


### PR DESCRIPTION
## Summary
- use `chartjs-gauge-v3` instead of the old gauge plugin
- load the new plugin from CDN in `index.html`
- update gauge options for new API
- refresh lock file with `npm install`
- document the new plugin in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849b7afdcc0832fbc5b40fe2a8de332