### PR TITLE
Add Ray charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bitcoin Dashboard
 
-This project contains a small dashboard (`index.html`) that displays Bitcoin price data, the Fear & Greed index, an ETH/BTC chart and a news feed. The page uses **Bootswatch** for styling and **Chart.js** for the BTC chart. JavaScript code lives in `src/dashboard.js`.
+This project contains a small dashboard (`index.html`) that displays Bitcoin price data, the Fear & Greed index, an ETH/BTC chart, RAY indicators and a news feed. The page uses **Bootswatch** for styling and **Chart.js** for the BTC chart. JavaScript code lives in `src/dashboard.js`.
 
 The layout now includes a responsive navbar, a hero banner and a footer. Custom styles and images live under the `assets/` folder.
 
@@ -45,6 +45,7 @@ The dashboard uses several public APIs. You can change them inside `src/dashboar
 
 - **Fear & Greed index**: `https://api.alternative.me/fng/?limit=30`
 - **Bitcoin prices**: `https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=30&interval=daily`
+- **Raydium data**: `https://api.coingecko.com/api/v3/coins/raydium/market_chart?vs_currency=usd&days=30&interval=daily`
 - **News feed**: `https://api.rss2json.com/v1/api.json?rss_url=https://news.google.com/rss/search?q=bitcoin`
 
 The news section pulls headlines from Google News using the rss2json service.

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         <ul class="navbar-nav ms-auto">
           <li class="nav-item"><a class="nav-link" href="#btc-section">BTC/F&G</a></li>
           <li class="nav-item"><a class="nav-link" href="#ethbtc-section">ETH/BTC</a></li>
+          <li class="nav-item"><a class="nav-link" href="#ray-section">RAY</a></li>
           <li class="nav-item"><a class="nav-link" href="#news-section">Noticias</a></li>
         </ul>
       </div>
@@ -45,16 +46,24 @@
       </div>
     </section>
 
-    <section id="ethbtc-section" class="mb-4">
-      <div class="card p-3">
-        <h2 class="h4">ETH/BTC</h2>
-        <div id="ethbtc-chart" style="height:300px"></div>
-      </div>
-    </section>
+  <section id="ethbtc-section" class="mb-4">
+    <div class="card p-3">
+      <h2 class="h4">ETH/BTC</h2>
+      <div id="ethbtc-chart" style="height:300px"></div>
+    </div>
+  </section>
 
-      <section id="google-news-section" class="mb-4">
-        <div class="card p-3">
-          <h2 class="h4">Noticias de Bitcoin</h2>
+  <section id="ray-section" class="mb-4">
+    <div class="card p-3">
+      <h2 class="h4">RAY</h2>
+      <canvas id="rayPriceChart" height="300"></canvas>
+      <canvas id="rayVolumeChart" height="300"></canvas>
+    </div>
+  </section>
+
+  <section id="google-news-section" class="mb-4">
+    <div class="card p-3">
+      <h2 class="h4">Noticias de Bitcoin</h2>
           <div class="news-container">
             <ul id="google-news-list" class="list-group"></ul>
           </div>

--- a/src/__tests__/dashboard.test.js
+++ b/src/__tests__/dashboard.test.js
@@ -1,5 +1,5 @@
 import {jest} from "@jest/globals";
-import {fetchGoogleNews, fetchBtcAndFng, initTradingView} from '../dashboard.js';
+import {fetchGoogleNews, fetchBtcAndFng, fetchRayData, initTradingView} from '../dashboard.js';
 
 describe('dashboard functions', () => {
   beforeEach(() => {
@@ -26,6 +26,18 @@ HTMLCanvasElement.prototype.getContext = jest.fn();
     global.Chart = jest.fn();
     document.body.innerHTML = '<div id="btc-fng-card"><canvas id="btcFngChart"></canvas><canvas id="fngGauge"></canvas></div>';
     await fetchBtcAndFng();
+    expect(global.Chart).toHaveBeenCalledTimes(2);
+  });
+
+  test('fetchRayData draws charts', async () => {
+    const ray = { prices: [[1, 1]], total_volumes: [[1, 100]] };
+    const serum = { prices: [[1, 0]], total_volumes: [[1, 50]] };
+    fetch
+      .mockResolvedValueOnce({ json: () => Promise.resolve(ray) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve(serum) });
+    global.Chart = jest.fn();
+    document.body.innerHTML = '<canvas id="rayPriceChart"></canvas><canvas id="rayVolumeChart"></canvas>';
+    await fetchRayData();
     expect(global.Chart).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Summary
- add RAY section in navbar and page
- plot Ray price with 7‑day SMA and volume comparison with Serum
- test the new fetchRayData function
- document Ray indicators and API endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849bafebf48832fa34021be7d83ac1d