### PR TITLE
Update asset handling and error messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ The layout now includes a responsive navbar, a hero banner and a footer. Custom 
    ```bash
    npm install
    ```
-2. Decode the asset files:
+2. Decode the Base64 images found under `assets/img/`:
    ```bash
    npm run extract-assets
+   ```
+   # or use the shell helper:
+   ```bash
+   scripts/extract_assets.sh
    ```
 3. Serve the page (for example with Python) and open it in your browser:
    ```bash
@@ -58,13 +62,14 @@ The default logo and hero background are provided only as Base64 text files so t
 
 ### Extracting provided images
 
-Some platforms do not allow binary files to be checked in directly. For that case,
-the repository also includes the images encoded as Base64 text (`logo.txt` and
-`hero-bg.txt`). Run the helper script to decode them:
+Some platforms do not allow binary files to be checked in directly. For that case
+the repository includes the images encoded as Base64 text files under
+`assets/img/` (e.g. `hero-bg.txt`). Decode them with the provided script or npm command:
 
 ```bash
+npm run extract-assets
+# or
 scripts/extract_assets.sh
 ```
-
-After running the script you will have `logo.png` and `hero-bg.jpg` in
+After running the script you will have the corresponding image files in
 `assets/img/` ready to use.

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           <li class="nav-item"><a class="nav-link" href="#btc-section">BTC/F&G</a></li>
           <li class="nav-item"><a class="nav-link" href="#ethbtc-section">ETH/BTC</a></li>
           <li class="nav-item"><a class="nav-link" href="#ray-section">RAY</a></li>
-          <li class="nav-item"><a class="nav-link" href="#news-section">Noticias</a></li>
+          <li class="nav-item"><a class="nav-link" href="#google-news-section">Noticias</a></li>
         </ul>
       </div>
     </div>

--- a/scripts/extract_assets.js
+++ b/scripts/extract_assets.js
@@ -1,18 +1,27 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-const assetsDir = path.join(__dirname, '..', 'assets');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
-if (!fs.existsSync(assetsDir)) {
-  console.error('Assets directory not found:', assetsDir);
+const imgDir = path.join(__dirname, '..', 'assets', 'img');
+
+if (!fs.existsSync(imgDir)) {
+  console.error('Assets directory not found:', imgDir);
   process.exit(1);
 }
 
-for (const file of fs.readdirSync(assetsDir)) {
+const mapping = {
+  'hero-bg.txt': 'hero-bg.jpg',
+  'logo.txt': 'logo.png'
+};
+
+for (const file of fs.readdirSync(imgDir)) {
   if (file.endsWith('.txt')) {
-    const inputPath = path.join(assetsDir, file);
-    const outputName = file.replace(/\.txt$/, '');
-    const outputPath = path.join(assetsDir, outputName);
+    const inputPath = path.join(imgDir, file);
+    const outputName = mapping[file] || file.replace(/\.txt$/, '');
+    const outputPath = path.join(imgDir, outputName);
     const base64 = fs.readFileSync(inputPath, 'utf8').trim();
     const buffer = Buffer.from(base64, 'base64');
     fs.writeFileSync(outputPath, buffer);

--- a/src/__tests__/dashboard.test.js
+++ b/src/__tests__/dashboard.test.js
@@ -36,9 +36,18 @@ HTMLCanvasElement.prototype.getContext = jest.fn();
       .mockResolvedValueOnce({ json: () => Promise.resolve(ray) })
       .mockResolvedValueOnce({ json: () => Promise.resolve(serum) });
     global.Chart = jest.fn();
-    document.body.innerHTML = '<canvas id="rayPriceChart"></canvas><canvas id="rayVolumeChart"></canvas>';
+    document.body.innerHTML = '<div><canvas id="rayPriceChart"></canvas><canvas id="rayVolumeChart"></canvas></div>';
     await fetchRayData();
     expect(global.Chart).toHaveBeenCalledTimes(2);
+  });
+
+  test('fetchRayData shows message on failure', async () => {
+    fetch.mockRejectedValueOnce(new Error('fail'));
+    document.body.innerHTML = '<div><canvas id="rayPriceChart"></canvas><canvas id="rayVolumeChart"></canvas></div>';
+    await fetchRayData();
+    const msg = document.querySelector('.error-message');
+    expect(msg).not.toBeNull();
+    expect(msg.textContent).toMatch(/RAY/);
   });
 
   test('initTradingView uses TradingView.widget', () => {

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -122,6 +122,7 @@ export async function fetchRayData() {
   const priceCanvas = document.getElementById('rayPriceChart');
   const volumeCanvas = document.getElementById('rayVolumeChart');
   if (!priceCanvas || !volumeCanvas) return;
+  const card = priceCanvas.parentElement;
 
   try {
     const [rayRes, serumRes] = await Promise.all([
@@ -166,8 +167,18 @@ export async function fetchRayData() {
       },
       options: { maintainAspectRatio: true }
     });
+    priceCanvas.style.display = 'block';
+    volumeCanvas.style.display = 'block';
+    card.querySelector('.error-message')?.remove();
   } catch (err) {
     console.error('Error fetching RAY data', err);
+    priceCanvas.style.display = 'none';
+    volumeCanvas.style.display = 'none';
+    card.querySelector('.error-message')?.remove();
+    const msg = document.createElement('div');
+    msg.className = 'text-danger error-message';
+    msg.textContent = 'Datos de RAY no disponibles';
+    card.appendChild(msg);
   }
 }
 


### PR DESCRIPTION
## Summary
- improve extract_assets.js to decode images in `assets/img/`
- clarify asset extraction instructions in README
- fix navbar link anchor in `index.html`
- show an error message when RAY data fetch fails
- test the new RAY error handling

## Testing
- `npm run extract-assets`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849c0625e38832fa870aa9dec0ee144