### PR TITLE
Fix asset extraction script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ The default logo and hero background are provided only as Base64 text files so t
 
 Some platforms do not allow binary files to be checked in directly. For that case,
 the repository also includes the images encoded as Base64 text (`logo.txt` and
-`hero-bg.txt`). Run the helper script to decode them:
+`hero-bg.txt`). Decode them with the npm script:
 
 ```bash
-scripts/extract_assets.sh
+npm run extract-assets
 ```
 
-After running the script you will have `logo.png` and `hero-bg.jpg` in
-`assets/img/` ready to use.
+After running the script you will have `assets/img/logo.png` and `assets/img/hero-bg.jpg`
+ready to use.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
-    "extract-assets": "node scripts/extract_assets.js"
+    "extract-assets": "node ./scripts/extract_assets.js"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/scripts/extract_assets.js
+++ b/scripts/extract_assets.js
@@ -1,7 +1,14 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-const assetsDir = path.join(__dirname, '..', 'assets');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const assetsDir = path.join(__dirname, '..', 'assets', 'img');
+
+const outputMap = {
+  'logo.txt': 'logo.png',
+  'hero-bg.txt': 'hero-bg.jpg',
+};
 
 if (!fs.existsSync(assetsDir)) {
   console.error('Assets directory not found:', assetsDir);
@@ -11,8 +18,12 @@ if (!fs.existsSync(assetsDir)) {
 for (const file of fs.readdirSync(assetsDir)) {
   if (file.endsWith('.txt')) {
     const inputPath = path.join(assetsDir, file);
-    const outputName = file.replace(/\.txt$/, '');
+    const outputName = outputMap[file] || file.replace(/\.txt$/, '');
     const outputPath = path.join(assetsDir, outputName);
+    if (fs.existsSync(outputPath)) {
+      console.log('Skipping existing', outputName);
+      continue;
+    }
     const base64 = fs.readFileSync(inputPath, 'utf8').trim();
     const buffer = Buffer.from(base64, 'base64');
     fs.writeFileSync(outputPath, buffer);


### PR DESCRIPTION
## Summary
- convert `scripts/extract_assets.js` to ES modules
- map `.txt` assets to final filenames and skip decoding existing files
- point npm script to asset extractor
- update README instructions for asset extraction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849c49b5078832f8caf4e5737ff2e2a