### PR TITLE
Add competitor volume comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bitcoin Dashboard
 
 This project contains a small dashboard (`index.html`) that displays Bitcoin price data, the Fear & Greed index, an ETH/BTC chart, RAY indicators and a news feed. The page uses **Bootswatch** for styling and **Chart.js** for the BTC chart. JavaScript code lives in `src/dashboard.js`.
+The RAY section now compares its trading volume against PancakeSwap (CAKE) and Cetus.
 
 The layout now includes a responsive navbar, a hero banner and a footer. Custom styles and images live under the `assets/` folder.
 
@@ -46,6 +47,8 @@ The dashboard uses several public APIs. You can change them inside `src/dashboar
 - **Fear & Greed index**: `https://api.alternative.me/fng/?limit=30`
 - **Bitcoin prices**: `https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=30&interval=daily`
 - **Raydium data**: `https://api.coingecko.com/api/v3/coins/raydium/market_chart?vs_currency=usd&days=30&interval=daily`
+- **PancakeSwap data**: `https://api.coingecko.com/api/v3/coins/pancakeswap-token/market_chart?vs_currency=usd&days=30&interval=daily`
+- **Cetus data**: `https://api.coingecko.com/api/v3/coins/cetus-protocol/market_chart?vs_currency=usd&days=30&interval=daily`
 - **News feed**: `https://api.rss2json.com/v1/api.json?rss_url=https://news.google.com/rss/search?q=bitcoin`
 
 The news section pulls headlines from Google News using the rss2json service.

--- a/src/__tests__/dashboard.test.js
+++ b/src/__tests__/dashboard.test.js
@@ -31,10 +31,12 @@ HTMLCanvasElement.prototype.getContext = jest.fn();
 
   test('fetchRayData draws charts', async () => {
     const ray = { prices: [[1, 1]], total_volumes: [[1, 100]] };
-    const serum = { prices: [[1, 0]], total_volumes: [[1, 50]] };
+    const cake = { total_volumes: [[1, 150]] };
+    const cetus = { total_volumes: [[1, 50]] };
     fetch
-      .mockResolvedValueOnce({ json: () => Promise.resolve(ray) })
-      .mockResolvedValueOnce({ json: () => Promise.resolve(serum) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ray) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(cake) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(cetus) });
     global.Chart = jest.fn();
     document.body.innerHTML = '<canvas id="rayPriceChart"></canvas><canvas id="rayVolumeChart"></canvas>';
     await fetchRayData();


### PR DESCRIPTION
## Summary
- fetch PancakeSwap and Cetus volumes
- show average 30-day volumes in a bar chart
- update tests for new API calls
- document competitor comparison and API endpoints

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c49c3574832fa57b19c18b0c3832