### PR TITLE
Add live price ticker

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -27,3 +27,11 @@ footer {
   font-size: 0.8rem;
   margin-left: 2px;
 }
+
+#price-ticker {
+  text-align: center;
+  padding: 0.5rem 0;
+}
+#price-ticker span {
+  margin: 0 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -30,6 +30,12 @@
     </div>
   </nav>
 
+  <div id="price-ticker" class="bg-light">
+    <span id="btc-price"></span>
+    <span id="eth-price"></span>
+    <span id="ray-price"></span>
+  </div>
+
   <header class="hero">
     <div class="container">
       <h1 class="display-4">El grupo de los próximos clase media</h1>

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -335,7 +335,30 @@ export function initTradingView() {
   });
 }
 
+export async function updateTicker() {
+  try {
+    const res = await fetch(
+      'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,raydium&vs_currencies=usd',
+      { cache: 'no-store' }
+    );
+    if (!res.ok) throw new Error('Failed to fetch prices');
+    const data = await res.json();
+    const btcEl = document.getElementById('btc-price');
+    const ethEl = document.getElementById('eth-price');
+    const rayEl = document.getElementById('ray-price');
+    if (btcEl) btcEl.textContent = `BTC: $${data.bitcoin.usd}`;
+    if (ethEl) ethEl.textContent = `ETH: $${data.ethereum.usd}`;
+    if (rayEl) rayEl.textContent = `RAY: $${data.raydium.usd}`;
+  } catch (err) {
+    console.error('Error updating ticker', err);
+  }
+}
+
 function initDashboard() {
+  if (document.getElementById('price-ticker')) {
+    updateTicker();
+    setInterval(updateTicker, 1000);
+  }
   fetchBtcAndFng();
   fetchGoogleNews();
   fetchRayData();


### PR DESCRIPTION
## Summary
- embed a live price ticker just below the navbar
- poll Coingecko every second and display BTC, ETH and RAY prices
- run `updateTicker()` from dashboard initialization
- add styles for centered ticker layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d693e06c832fbbb14d5bd97ce52a