### PR TITLE
Remove Google News feed and add Telegram link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bitcoin Dashboard
 
-This project contains a small dashboard (`index.html`) that displays Bitcoin price data, the Fear & Greed index, an ETH/BTC chart, RAY indicators and a news feed. The page uses **Bootswatch** for styling and **Chart.js** for the BTC chart. JavaScript code lives in `src/dashboard.js`.
+This project contains a small dashboard (`index.html`) that displays Bitcoin price data, the Fear & Greed index, an ETH/BTC chart, RAY indicators and a link to our Telegram group. The page uses **Bootswatch** for styling and **Chart.js** for the BTC chart. JavaScript code lives in `src/dashboard.js`.
 The RAY section now compares its trading volume against PancakeSwap (CAKE) and Cetus.
 
 The layout now includes a responsive navbar, a hero banner and a footer. Custom styles and images live under the `assets/` folder.
@@ -49,10 +49,9 @@ The dashboard uses several public APIs. You can change them inside `src/dashboar
 - **Raydium data**: `https://api.coingecko.com/api/v3/coins/raydium/market_chart?vs_currency=usd&days=30&interval=daily`
 - **PancakeSwap data**: `https://api.coingecko.com/api/v3/coins/pancakeswap-token/market_chart?vs_currency=usd&days=30&interval=daily`
 - **Cetus data**: `https://api.coingecko.com/api/v3/coins/cetus-protocol/market_chart?vs_currency=usd&days=30&interval=daily`
-- **News feed**: `https://api.rss2json.com/v1/api.json?rss_url=https://news.google.com/rss/search?q=bitcoin`
+- **Telegram group**: <https://t.me/NewsAgregatorBtCryptoWhale>
 
-The news section pulls headlines from Google News using the rss2json service.
-It refreshes automatically every five minutes to show the latest articles.
+The news section has been replaced with a simple link to our Telegram group where updates are posted regularly.
 
 ## Adding images
 

--- a/index.html
+++ b/index.html
@@ -100,20 +100,11 @@
 
   <section id="google-news-section" class="mb-4">
     <div class="card p-3">
-      <h2 class="h4">Noticias de Bitcoin</h2>
-      <div id="news-spinner" class="text-center my-3 d-none">
-        <div class="spinner-border" role="status">
-          <span class="visually-hidden">Loading...</span>
-        </div>
-      </div>
-          <div class="news-container">
-            <ul id="google-news-list" class="list-group"></ul>
-          </div>
-          <div id="x-feed" class="mt-3">
-            <a class="twitter-timeline" data-height="300" href="https://twitter.com/Bitcoin?ref_src=twsrc%5Etfw">Tweets by Bitcoin</a>
-          </div>
-        </div>
-      </section>
+      <h2 class="h4">Comunidad</h2>
+      <p>Únete a nuestro grupo de Telegram para recibir noticias y debatir sobre criptomonedas.</p>
+      <a class="btn btn-primary" target="_blank" href="https://t.me/NewsAgregatorBtCryptoWhale">Ir al grupo</a>
+    </div>
+  </section>
   </div>
 
   <footer class="bg-light">
@@ -124,7 +115,6 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://s3.tradingview.com/tv.js"></script>
-  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
   <script type="module" src="src/dashboard.js"></script>
 </body>
 </html>

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -337,13 +337,11 @@ export function initTradingView() {
 
 function initDashboard() {
   fetchBtcAndFng();
-  fetchGoogleNews();
   fetchRayData();
   fetchDefiComparison();
   initTradingView();
   const defiTable = document.getElementById('defi-table');
   if (defiTable) makeSortable(defiTable);
-  setInterval(fetchGoogleNews, 300000);
   setInterval(fetchDefiComparison, 300000);
 }
 


### PR DESCRIPTION
## Summary
- replace the Google News section with a Telegram invite
- remove Twitter widget markup and script
- stop calling `fetchGoogleNews` in the dashboard
- document the Telegram group in the README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d6597e90832f921b5eae008c765c