### PR TITLE
Update crypto dashboard design

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,10 +1,20 @@
 body {
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
-#ethbtc-price {
-  font-weight: bold;
+
+.price-change-up {
+  color: #198754;
 }
+
+.price-change-down {
+  color: #dc3545;
+}
+
 .spinner-border {
   width: 2rem;
   height: 2rem;
+}
+
+#volumeChart {
+  max-height: 400px;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,145 +1,248 @@
-const ethbtcChartCtx = document.getElementById('ethbtcChart');
-const volumeChartCtx = document.getElementById('volumeChart');
+// Elementos de los gráficos
+const ethbtcCtx = document.getElementById('ethbtcChart');
+const volumeCtx = document.getElementById('volumeChart');
+const fngCtx = document.getElementById('fngGauge');
+
 let ethbtcChart;
 let volumeChart;
+let fngChart;
 
-async function loadEthBtc() {
-  const priceEl = document.getElementById('ethbtc-price');
-  const changeEl = document.getElementById('ethbtc-change');
-  const updatedEl = document.getElementById('ethbtc-updated');
-  const loadingEl = document.getElementById('ethbtc-loading');
-  const errorEl = document.getElementById('ethbtc-error');
-  loadingEl.style.display = 'block';
+// ---- Obtención de precios y variaciones ----
+async function loadPrices() {
+  const errorEl = document.getElementById('prices-error');
+  const updatedEl = document.getElementById('prices-updated');
   errorEl.textContent = '';
   try {
-    const priceRes = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=btc&include_24hr_change=true');
-    const priceData = await priceRes.json();
-    const ratio = priceData.ethereum.btc;
-    const change = priceData.ethereum.btc_24h_change;
-    priceEl.textContent = ratio.toFixed(6) + ' BTC';
-    changeEl.innerHTML = `${change >= 0 ? '<i class="bi bi-arrow-up"></i>' : '<i class="bi bi-arrow-down"></i>'} ${change.toFixed(2)}%`;
-    changeEl.className = change >= 0 ? 'text-success' : 'text-danger';
-    updatedEl.textContent = 'Última actualización: ' + new Date().toLocaleTimeString();
+    const res = await fetch(
+      'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,raydium&vs_currencies=usd&include_24hr_change=true'
+    );
+    const data = await res.json();
 
-    const [ethHistRes, btcHistRes] = await Promise.all([
+    updatePrice('btc', data.bitcoin.usd, data.bitcoin.usd_24h_change);
+    updatePrice('eth', data.ethereum.usd, data.ethereum.usd_24h_change);
+    updatePrice('ray', data.raydium.usd, data.raydium.usd_24h_change);
+
+    updatedEl.textContent = 'Última actualización: ' + new Date().toLocaleTimeString();
+  } catch (err) {
+    console.error('Error en precios', err);
+    errorEl.textContent = 'Datos no disponibles';
+  }
+}
+
+function updatePrice(prefix, price, change) {
+  const priceEl = document.getElementById(prefix + '-price');
+  const changeEl = document.getElementById(prefix + '-change');
+  priceEl.textContent = '$' + price.toLocaleString('en-US');
+  const arrow = change >= 0 ? 'bi-arrow-up' : 'bi-arrow-down';
+  changeEl.innerHTML = `<i class="bi ${arrow}"></i> ${change.toFixed(2)}%`;
+  changeEl.className = change >= 0 ? 'price-change-up' : 'price-change-down';
+}
+
+// ---- Gráfico ETH/BTC ----
+async function loadEthBtc() {
+  const loading = document.getElementById('ethbtc-loading');
+  const errorEl = document.getElementById('ethbtc-error');
+  loading.style.display = 'block';
+  errorEl.textContent = '';
+
+  try {
+    const [ethRes, btcRes] = await Promise.all([
       fetch('https://api.coingecko.com/api/v3/coins/ethereum/market_chart?vs_currency=usd&days=30&interval=daily'),
       fetch('https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=30&interval=daily')
     ]);
-    const ethHist = await ethHistRes.json();
-    const btcHist = await btcHistRes.json();
+    const eth = await ethRes.json();
+    const btc = await btcRes.json();
 
-    const labels = ethHist.prices.map(p => new Date(p[0]).toISOString().split('T')[0]);
-    const ratios = ethHist.prices.map((p, i) => p[1] / btcHist.prices[i][1]);
+    const labels = eth.prices.map(p => new Date(p[0]).toISOString().split('T')[0]);
+    const ratios = eth.prices.map((p, i) => p[1] / btc.prices[i][1]);
 
-    if (ethbtcChart) ethbtcChart.destroy();
-    ethbtcChart = new Chart(ethbtcChartCtx, {
+    ethbtcChart?.destroy();
+    ethbtcChart = new Chart(ethbtcCtx, {
       type: 'line',
       data: {
         labels,
         datasets: [{
           label: 'ETH/BTC',
           data: ratios,
-          borderColor: 'cyan',
+          borderColor: '#0dcaf0',
           tension: 0.2,
           fill: false
         }]
       },
       options: {
+        responsive: true,
         plugins: { legend: { display: false } },
+        interaction: { mode: 'index', intersect: false },
         scales: {
           x: { title: { display: false } },
-          y: { title: { display: false } }
+          y: { title: { display: 'Ratio' } }
         }
       }
     });
-    ethbtcChartCtx.style.display = 'block';
+
+    ethbtcCtx.style.display = 'block';
   } catch (err) {
-    console.error('Error cargando ETH/BTC', err);
-    errorEl.textContent = 'Datos no disponibles actualmente';
+    console.error('Error ETH/BTC', err);
+    errorEl.textContent = 'Datos no disponibles';
   } finally {
-    loadingEl.style.display = 'none';
+    loading.style.display = 'none';
   }
 }
 
+// ---- Gráfico de volúmenes ----
 async function loadVolumes() {
-  const loadingEl = document.getElementById('volume-loading');
-  const summaryEl = document.getElementById('volume-summary');
+  const loading = document.getElementById('volume-loading');
   const errorEl = document.getElementById('volume-error');
-  loadingEl.style.display = 'block';
+  const summaryEl = document.getElementById('volume-summary');
+  loading.style.display = 'block';
   errorEl.textContent = '';
+
   try {
-    const [rayRes, cakeRes, cetusRes] = await Promise.all([
+    const [rayRes, cakeRes, cetusRes, orcaRes, uniRes] = await Promise.all([
       fetch('https://api.coingecko.com/api/v3/coins/raydium/market_chart?vs_currency=usd&days=30&interval=daily'),
       fetch('https://api.coingecko.com/api/v3/coins/pancakeswap-token/market_chart?vs_currency=usd&days=30&interval=daily'),
-      fetch('https://api.coingecko.com/api/v3/coins/cetus-protocol/market_chart?vs_currency=usd&days=30&interval=daily')
+      fetch('https://api.coingecko.com/api/v3/coins/cetus-protocol/market_chart?vs_currency=usd&days=30&interval=daily'),
+      fetch('https://api.coingecko.com/api/v3/coins/orca/market_chart?vs_currency=usd&days=30&interval=daily'),
+      fetch('https://api.coingecko.com/api/v3/coins/uniswap/market_chart?vs_currency=usd&days=30&interval=daily')
     ]);
-    const ray = await rayRes.json();
-    const cake = await cakeRes.json();
-    const cetus = await cetusRes.json();
+
+    const [ray, cake, cetus, orca, uni] = await Promise.all([
+      rayRes.json(),
+      cakeRes.json(),
+      cetusRes.json(),
+      orcaRes.json(),
+      uniRes.json()
+    ]);
+
     const labels = ray.total_volumes.map(v => new Date(v[0]).toISOString().split('T')[0]);
     const rayVol = ray.total_volumes.map(v => v[1]);
     const cakeVol = cake.total_volumes.map(v => v[1]);
     const cetusVol = cetus.total_volumes.map(v => v[1]);
+    const orcaVol = orca.total_volumes.map(v => v[1]);
+    const uniVol = uni.total_volumes.map(v => v[1]);
 
-    if (volumeChart) volumeChart.destroy();
-    volumeChart = new Chart(volumeChartCtx, {
+    volumeChart?.destroy();
+    volumeChart = new Chart(volumeCtx, {
       type: 'line',
       data: {
         labels,
         datasets: [
-          { label: 'RAY', data: rayVol, borderColor: '#0d6efd', tension: 0.2, fill: false },
-          { label: 'CAKE', data: cakeVol, borderColor: '#adb5bd', tension: 0.2, fill: false },
-          { label: 'CETUS', data: cetusVol, borderColor: '#20c997', tension: 0.2, fill: false }
+          { label: 'RAY', data: rayVol, borderColor: '#0d6efd', borderWidth: 3, tension: 0.2, fill: false },
+          { label: 'CAKE', data: cakeVol, borderColor: '#adb5bd', borderDash: [5,5], tension: 0.2, fill: false },
+          { label: 'CETUS', data: cetusVol, borderColor: '#20c997', borderDash: [5,2], tension: 0.2, fill: false },
+          { label: 'ORCA', data: orcaVol, borderColor: '#ffc107', borderDash: [2,3], tension: 0.2, fill: false },
+          { label: 'UNI', data: uniVol, borderColor: '#6610f2', borderDash: [6,3], tension: 0.2, fill: false }
         ]
       },
       options: {
-        plugins: { legend: { display: true } },
+        responsive: true,
+        interaction: { mode: 'index', intersect: false },
         scales: {
-          y: {
-            title: { display: true, text: 'Volumen (USD)' }
+          y: { title: { display: true, text: 'Volumen (USD)' } }
+        }
+      }
+    });
+
+    volumeCtx.style.display = 'block';
+
+    const volumes24 = [rayVol, cakeVol, cetusVol, orcaVol, uniVol].map(arr => arr[arr.length - 1]);
+    const total = volumes24.reduce((a, b) => a + b, 0);
+    const share = total ? (volumes24[0] / total * 100).toFixed(1) : '0';
+    summaryEl.textContent =
+      `Vol. 24h – RAY $${(volumes24[0]/1e6).toFixed(2)}M | CAKE $${(volumes24[1]/1e6).toFixed(2)}M | ` +
+      `CETUS $${(volumes24[2]/1e6).toFixed(2)}M | ORCA $${(volumes24[3]/1e6).toFixed(2)}M | ` +
+      `UNI $${(volumes24[4]/1e6).toFixed(2)}M. Cuota RAY: ${share}% del total.`;
+  } catch (err) {
+    console.error('Error en volúmenes', err);
+    errorEl.textContent = 'Datos no disponibles';
+  } finally {
+    loading.style.display = 'none';
+  }
+}
+
+// ---- Gauge Fear & Greed ----
+async function loadFng() {
+  const errorEl = document.getElementById('fng-error');
+  const textEl = document.getElementById('fng-text');
+  errorEl.textContent = '';
+
+  try {
+    const res = await fetch('https://api.alternative.me/fng/?limit=1&format=json');
+    const data = await res.json();
+    const value = Number(data.data[0].value);
+    const label = data.data[0].value_classification;
+
+    fngChart?.destroy();
+    fngChart = new Chart(fngCtx, {
+      type: 'gauge',
+      data: {
+        datasets: [{
+          value,
+          data: [20, 20, 20, 20, 20],
+          minValue: 0,
+          backgroundColor: ['#dc3545', '#fd7e14', '#ffc107', '#198754', '#0d6efd']
+        }]
+      },
+      options: {
+        responsive: true,
+        needle: { radiusPercentage: 2, widthPercentage: 3, lengthPercentage: 80 },
+        valueLabel: { display: false },
+        trackColor: '#343a40',
+        plugins: {
+          legend: {
+            display: false
           }
         }
       }
     });
-    volumeChartCtx.style.display = 'block';
-    const r24 = rayVol[rayVol.length - 1];
-    const c24 = cakeVol[cakeVol.length - 1];
-    const ct24 = cetusVol[cetusVol.length - 1];
-    const pctCake = c24 ? (r24 / c24 * 100).toFixed(1) : '0';
-    const pctCetus = ct24 ? (r24 / ct24 * 100).toFixed(1) : '0';
-    summaryEl.textContent = `Vol. 24h: RAY $${(r24/1e6).toFixed(2)} M | CAKE $${(c24/1e6).toFixed(2)} M | CETUS $${(ct24/1e6).toFixed(2)} M. RAY equivale al ${pctCake}% del volumen de PancakeSwap y ${pctCetus}% del de Cetus.`;
+
+    textEl.textContent = `Actualmente: ${label}`;
   } catch (err) {
-    console.error('Error cargando volúmenes', err);
-    errorEl.textContent = 'Datos no disponibles actualmente';
-  } finally {
-    loadingEl.style.display = 'none';
+    console.error('Error Fear & Greed', err);
+    errorEl.textContent = 'Datos no disponibles';
   }
 }
 
-async function loadSecondary() {
-  const btcPriceEl = document.getElementById('btc-price');
-  const fngValueEl = document.getElementById('fng-value');
+// ---- Noticias vía RSS ----
+async function loadNews() {
+  const loader = document.getElementById('news-loading');
+  const list = document.getElementById('news-list');
+  const errorEl = document.getElementById('news-error');
+  loader.style.display = 'block';
+  errorEl.textContent = '';
+  list.innerHTML = '';
+
   try {
-    const [btcRes, fngRes] = await Promise.all([
-      fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd&include_24hr_change=true'),
-      fetch('https://api.alternative.me/fng/?limit=1&format=json')
-    ]);
-    const btcData = await btcRes.json();
-    const fngData = await fngRes.json();
-    const btcPrice = btcData.bitcoin.usd;
-    const btcChange = btcData.bitcoin.usd_24h_change;
-    btcPriceEl.innerHTML = `$${btcPrice.toLocaleString()} <small class="${btcChange>=0?'text-success':'text-danger'}">${btcChange.toFixed(2)}%</small>`;
-    const fng = fngData.data[0];
-    fngValueEl.textContent = `${fng.value} – ${fng.value_classification}`;
+    const res = await fetch(
+      'https://api.rss2json.com/v1/api.json?rss_url=https://news.google.com/rss/search?q=cryptocurrency&hl=es&gl=ES&ceid=ES:es'
+    );
+    const data = await res.json();
+
+    data.items.slice(0, 5).forEach(item => {
+      const li = document.createElement('li');
+      li.className = 'list-group-item';
+      const date = new Date(item.pubDate).toLocaleDateString();
+      li.innerHTML = `<a href="${item.link}" target="_blank">${item.title}</a> <small class="text-muted d-block">${date}</small>`;
+      list.appendChild(li);
+    });
   } catch (err) {
-    console.error('Error secundario', err);
+    console.error('Error noticias', err);
+    errorEl.textContent = 'Datos no disponibles';
+  } finally {
+    loader.style.display = 'none';
   }
 }
 
+// ---- Inicialización ----
 document.addEventListener('DOMContentLoaded', () => {
+  loadPrices();
   loadEthBtc();
   loadVolumes();
-  loadSecondary();
+  loadFng();
+  loadNews();
+  setInterval(loadPrices, 5 * 60 * 1000);
   setInterval(loadEthBtc, 5 * 60 * 1000);
-  setInterval(loadSecondary, 5 * 60 * 1000);
+  setInterval(loadVolumes, 10 * 60 * 1000);
+  setInterval(loadFng, 5 * 60 * 1000);
+  setInterval(loadNews, 15 * 60 * 1000);
 });

--- a/index.html
+++ b/index.html
@@ -8,11 +8,12 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="assets/css/styles.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-gauge-v3@3.0.0/dist/index.min.js"></script>
 </head>
 <body>
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
     <div class="container">
-      <a class="navbar-brand" href="#">Crypto Dashboard</a>
+      <span class="navbar-brand">Crypto Dashboard</span>
       <div class="ms-auto">
         <a href="https://t.me/NewsAgregatorBtCryptoWhale" target="_blank" class="nav-link text-white">
           <i class="bi bi-telegram"></i> Comunidad
@@ -22,48 +23,74 @@
   </nav>
 
   <main class="container my-4">
-    <section id="ethbtc" class="mb-5">
-      <h2 class="h4">ETH/BTC – Relación Ethereum/Bitcoin</h2>
-      <div id="ethbtc-info" class="mb-2">
-        <span id="ethbtc-price" class="h3 me-2"></span>
-        <span id="ethbtc-change"></span>
-        <small id="ethbtc-updated" class="text-muted d-block"></small>
+    <!-- Panel de precios -->
+    <section id="prices" class="mb-4">
+      <div class="card p-3">
+        <div class="row text-center" id="prices-container">
+          <div class="col" id="btc-panel">
+            <h6 class="mb-1">Bitcoin (BTC)</h6>
+            <div class="h5" id="btc-price"></div>
+            <div id="btc-change"></div>
+          </div>
+          <div class="col" id="eth-panel">
+            <h6 class="mb-1">Ethereum (ETH)</h6>
+            <div class="h5" id="eth-price"></div>
+            <div id="eth-change"></div>
+          </div>
+          <div class="col" id="ray-panel">
+            <h6 class="mb-1">Raydium (RAY)</h6>
+            <div class="h5" id="ray-price"></div>
+            <div id="ray-change"></div>
+          </div>
+        </div>
+        <small id="prices-updated" class="text-muted d-block mt-2"></small>
+        <p id="prices-error" class="text-danger mt-1"></p>
       </div>
+    </section>
+
+    <!-- Gráfico ETH/BTC -->
+    <section id="ethbtc-section" class="mb-4">
+      <h2 class="h5">Relación ETH/BTC</h2>
       <div class="position-relative">
         <div id="ethbtc-loading" class="text-center my-3">
           <div class="spinner-border" role="status"></div>
         </div>
-        <canvas id="ethbtcChart" height="300" style="display:none;"></canvas>
+        <canvas id="ethbtcChart" height="250" style="display:none;"></canvas>
       </div>
       <p id="ethbtc-error" class="text-danger"></p>
     </section>
 
-    <section id="volumes" class="mb-5">
-      <h2 class="h4">Raydium vs PancakeSwap vs Cetus – Volumen de Trading</h2>
-      <p class="text-muted">Comparativa de volúmenes de trading (USD) – últimos 30 días</p>
+    <!-- Volúmenes comparativos -->
+    <section id="volumes" class="mb-4">
+      <h2 class="h5">Volúmenes DEX (30 días)</h2>
       <div class="position-relative">
         <div id="volume-loading" class="text-center my-3">
           <div class="spinner-border" role="status"></div>
         </div>
-        <canvas id="volumeChart" height="300" style="display:none;"></canvas>
+        <canvas id="volumeChart" height="300" style="display:none; max-height:400px;"></canvas>
       </div>
       <p id="volume-summary" class="mt-2"></p>
       <p id="volume-error" class="text-danger"></p>
     </section>
 
-    <section id="secondary" class="row g-3 mb-5">
-      <div class="col-md-6">
-        <div class="card p-3" id="btc-card">
-          <h5 class="card-title">Precio BTC</h5>
-          <p id="btc-price" class="h4 mb-0"></p>
-        </div>
+    <!-- Fear & Greed -->
+    <section id="fng-section" class="mb-4">
+      <h2 class="h5">Índice Miedo &amp; Codicia</h2>
+      <div class="d-flex align-items-center">
+        <canvas id="fngGauge" width="200" height="120"></canvas>
+        <p class="ms-3" id="fng-text"></p>
       </div>
-      <div class="col-md-6">
-        <div class="card p-3" id="fng-card">
-          <h5 class="card-title">Índice Miedo/Codicia</h5>
-          <p id="fng-value" class="h4 mb-0"></p>
-        </div>
+      <p id="fng-error" class="text-danger"></p>
+    </section>
+
+    <!-- Noticias -->
+    <section id="news" class="mb-4">
+      <h2 class="h5">Noticias recientes</h2>
+      <div id="news-loading" class="text-center my-3">
+        <div class="spinner-border" role="status"></div>
       </div>
+      <ul id="news-list" class="list-group"></ul>
+      <p id="news-error" class="text-danger"></p>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- revamp index layout with compact price snapshot, volumes, ETH/BTC ratio, gauge and news
- simplify styling
- implement new logic for fetching prices, volumes, fear & greed gauge and RSS news

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849df0cfa00832f882bfab6c45d1bc5