### PR TITLE
Remove redundant CDN script tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,8 +87,6 @@
     </a>
   </footer>
 
-  <script defer src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.esm.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/chartjs-gauge-v3@3.0.0/dist/index.esm.js"></script>
   <script type="module" defer src="assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify `index.html` by removing direct CDN script tags for Chart.js and chartjs-gauge

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849f42a3800832fbd042216fa8aebda