### PR TITLE
Fix fear & greed gauge

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -30,7 +30,7 @@ function start() {
       .finally(tick),
 
     fetchGauge()
-      .then(v => renderGauge(document.getElementById('fngGauge'), v))
+      .then(data => renderGauge(document.getElementById('fngGauge'), data))
       .catch(() => showError('fng-error', 'Datos no disponibles'))
       .finally(tick),
 

--- a/assets/js/modules/api.js
+++ b/assets/js/modules/api.js
@@ -66,7 +66,11 @@ export async function fetchVolumes() {
 export async function fetchGauge() {
   try {
     const data = await getJSON('https://api.alternative.me/fng/?limit=1&format=json');
-    return Number(data.data[0].value);
+    const latest = data.data[0];
+    return {
+      value: Number(latest.value),
+      classification: latest.value_classification
+    };
   } catch (err) {
     console.error('F&G', err);
     throw err;

--- a/assets/js/modules/charts.js
+++ b/assets/js/modules/charts.js
@@ -43,8 +43,9 @@ export function renderVolumes(ctx, labels, datasets, onComplete) {
   });
 }
 
-export function renderGauge(ctx, value, onComplete) {
-  return new Chart(ctx, {
+export function renderGauge(ctx, data, onComplete) {
+  const { value, classification } = typeof data === 'object' ? data : { value: data, classification: '' };
+  const chart = new Chart(ctx, {
     type: 'gauge',
     data: {
       datasets: [
@@ -58,13 +59,16 @@ export function renderGauge(ctx, value, onComplete) {
     },
     options: {
       responsive: true,
-      rotation: 180,
+      rotation: -90,
       circumference: 180,
       needle: { radiusPercentage: 2, widthPercentage: 3, lengthPercentage: 80 },
-      valueLabel: { display: false },
+      valueLabel: { display: true },
       trackColor: '#343a40',
       plugins: { legend: { display: false } },
       animation: { onComplete },
     },
   });
+  const label = document.getElementById('fng-label');
+  if (label) label.textContent = classification ? `${classification} (${value})` : value;
+  return chart;
 }

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
       <div class="col-md-4 d-flex flex-column align-items-center">
         <h2 class="h6">Miedo &amp; Codicia</h2>
         <canvas id="fngGauge" width="200" height="120" aria-label="Fear and Greed gauge" role="img"></canvas>
+        <div id="fng-label" class="mt-2 fw-bold"></div>
         <p id="fng-error" class="text-danger"></p>
       </div>
       <div class="col-md-4">


### PR DESCRIPTION
## Summary
- return classification along with the fear & greed value
- show classification text and rotate the gauge upwards
- update index to include label next to the gauge

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a0562396c832fa2892c3b55ceb216