### PR TITLE
Improve F&G handling and timestamp updates

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,6 +1,6 @@
 import { fetchSnapshot, fetchEthBtc, fetchVolumes, fetchGauge, fetchNews } from './modules/api.js';
-import { renderEthBtc, renderVolumes, renderGauge } from './modules/charts.js';
-import { initLoader, renderSnapshot, renderNews, showError } from './modules/ui.js';
+import { renderEthBtc, renderVolumes } from './modules/charts.js';
+import { initLoader, renderSnapshot, renderNews, showError, renderFngGauge } from './modules/ui.js';
 
 function start() {
   const tick = initLoader(5);
@@ -30,7 +30,7 @@ function start() {
       .finally(tick),
 
     fetchGauge()
-      .then(data => renderGauge(document.getElementById('fngGauge'), data))
+      .then(renderFngGauge)
       .catch(() => showError('fng-error', 'Datos no disponibles'))
       .finally(tick),
 

--- a/assets/js/modules/charts.js
+++ b/assets/js/modules/charts.js
@@ -1,10 +1,10 @@
 import { Chart, registerables } from '../vendor/chart.esm.js';
-import '../vendor/chartjs-gauge.esm.js';
+import { setUpdated } from './ui.js';
 
 Chart.register(...registerables);
 
 export function renderEthBtc(ctx, labels, ratios, onComplete) {
-  return new Chart(ctx, {
+  const chart = new Chart(ctx, {
     type: 'line',
     data: {
       labels,
@@ -28,10 +28,12 @@ export function renderEthBtc(ctx, labels, ratios, onComplete) {
       },
     },
   });
+  setUpdated('ethbtc-updated');
+  return chart;
 }
 
 export function renderVolumes(ctx, labels, datasets, onComplete) {
-  return new Chart(ctx, {
+  const chart = new Chart(ctx, {
     type: 'line',
     data: { labels, datasets },
     options: {
@@ -41,34 +43,6 @@ export function renderVolumes(ctx, labels, datasets, onComplete) {
       scales: { y: { title: { display: true, text: 'Volumen (USD)' } } },
     },
   });
-}
-
-export function renderGauge(ctx, data, onComplete) {
-  const { value, classification } = typeof data === 'object' ? data : { value: data, classification: '' };
-  const chart = new Chart(ctx, {
-    type: 'gauge',
-    data: {
-      datasets: [
-        {
-          value,
-          data: [20, 20, 20, 20, 20],
-          minValue: 0,
-          backgroundColor: ['#dc3545', '#fd7e14', '#ffc107', '#198754', '#0d6efd'],
-        },
-      ],
-    },
-    options: {
-      responsive: true,
-      rotation: -90,
-      circumference: 180,
-      needle: { radiusPercentage: 2, widthPercentage: 3, lengthPercentage: 80 },
-      valueLabel: { display: true },
-      trackColor: '#343a40',
-      plugins: { legend: { display: false } },
-      animation: { onComplete },
-    },
-  });
-  const label = document.getElementById('fng-label');
-  if (label) label.textContent = classification ? `${classification} (${value})` : value;
+  setUpdated('volume-updated');
   return chart;
 }

--- a/assets/js/modules/ui.js
+++ b/assets/js/modules/ui.js
@@ -77,4 +77,26 @@ export function renderNews(items) {
     li.innerHTML = `<a href="${it.link}" target="_blank">${it.title}</a> <small class="text-muted d-block">${date}</small>`;
     list.appendChild(li);
   });
+  setUpdated('news-updated');
+}
+
+export function setUpdated(id) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = `Actualizado: ${new Date().toLocaleTimeString()}`;
+}
+
+export function renderFngGauge(data) {
+  const bar = document.getElementById('fng-bar');
+  const label = document.getElementById('fng-label');
+  if (!bar || !label) return;
+  const { value, classification } = typeof data === 'object' ? data : { value: data, classification: '' };
+  bar.style.width = `${value}%`;
+  let color = '#0d6efd';
+  if (value < 25) color = '#dc3545';
+  else if (value < 50) color = '#fd7e14';
+  else if (value < 75) color = '#ffc107';
+  else color = '#198754';
+  bar.style.backgroundColor = color;
+  label.textContent = classification ? `${classification} (${value})` : value;
+  setUpdated('fng-updated');
 }

--- a/index.html
+++ b/index.html
@@ -56,13 +56,17 @@
       </div>
       <div class="col-md-4 d-flex flex-column align-items-center">
         <h2 class="h6">Miedo &amp; Codicia</h2>
-        <canvas id="fngGauge" width="200" height="120" aria-label="Fear and Greed gauge" role="img"></canvas>
+        <div class="progress w-100" style="height:20px">
+          <div id="fng-bar" class="progress-bar" style="width:0%"></div>
+        </div>
         <div id="fng-label" class="mt-2 fw-bold"></div>
+        <small id="fng-updated" class="text-muted"></small>
         <p id="fng-error" class="text-danger"></p>
       </div>
       <div class="col-md-4">
         <h2 class="h6">ETH/BTC</h2>
         <canvas id="ethbtcChart" height="250" aria-label="ETH/BTC" role="img"></canvas>
+        <small id="ethbtc-updated" class="text-muted d-block mt-1"></small>
         <p id="ethbtc-error" class="text-danger"></p>
       </div>
     </div>
@@ -71,11 +75,13 @@
       <div class="col-lg-8">
         <h2 class="h6">Volúmenes DEX 30d</h2>
         <canvas id="volumeChart" height="300" aria-label="Volúmenes DEX" role="img"></canvas>
+        <small id="volume-updated" class="text-muted d-block mt-1"></small>
         <p id="volume-error" class="text-danger"></p>
       </div>
       <div class="col-lg-4">
         <h2 class="h6">Últimas noticias</h2>
         <ul id="news-list" class="list-group"></ul>
+        <small id="news-updated" class="text-muted d-block mt-1"></small>
         <p id="news-error" class="text-danger"></p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace Fear & Greed gauge canvas with a simple progress bar
- show last updated time for all sections
- simplify gauge rendering logic in `ui.js`
- update charts module to record timestamps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a073c9538832fa737f60d800f8cb3