### PR TITLE
Implement retry logic for API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ npm test
 - **Alternative.me** – Fear & Greed index
 - **Google News RSS (via rss2json)** – latest cryptocurrency headlines
 
+## Error handling
+
+API requests are performed through a helper that retries failed fetches up to
+two times with a short delay. All exported functions in `api.js` use this helper
+so that temporary network issues are automatically mitigated.
+
 ## Available scripts
 
 - `npm test` – run Jest unit tests

--- a/assets/js/modules/api.js
+++ b/assets/js/modules/api.js
@@ -7,10 +7,20 @@ function fetchWithTimeout(url, options = {}) {
     .finally(() => clearTimeout(timer));
 }
 
-async function getJSON(url) {
-  const res = await fetchWithTimeout(url);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json();
+async function getJSON(url, retries = 2) {
+  let lastErr;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetchWithTimeout(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return await res.json();
+    } catch (err) {
+      lastErr = err;
+      if (attempt === retries) break;
+      await new Promise(r => setTimeout(r, 100));
+    }
+  }
+  throw lastErr;
 }
 
 /** CoinGecko: precios y cambios 24h */

--- a/src/__tests__/dashboard.test.js
+++ b/src/__tests__/dashboard.test.js
@@ -1,5 +1,6 @@
 import {jest} from "@jest/globals";
 import {fetchGoogleNews, fetchBtcAndFng, fetchRayData, initTradingView} from '../dashboard.js';
+import {fetchSnapshot} from '../../assets/js/modules/api.js';
 
 describe('dashboard functions', () => {
   beforeEach(() => {
@@ -48,5 +49,15 @@ HTMLCanvasElement.prototype.getContext = jest.fn();
     document.body.innerHTML = '<div id="ethbtc-chart"></div>';
     initTradingView();
     expect(global.TradingView.widget).toHaveBeenCalledWith(expect.objectContaining({ symbol: 'BINANCE:ETHBTC' }));
+  });
+
+  test('fetchSnapshot retries on failure', async () => {
+    const data = { ok: true };
+    fetch
+      .mockRejectedValueOnce(new Error('net'))
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(data) });
+    const result = await fetchSnapshot();
+    expect(result).toEqual(data);
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- retry API helper when fetch fails
- adjust tests for retry logic
- note error handling in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0f2933f8832fb5498bf1f899f53d