### PR TITLE
Add automatic data refresh with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ JavaScript code is organised in ES modules under `assets/js/`:
    # then visit http://localhost:8000/index.html
    ```
 
-The dashboard fetches live data from the internet so an active connection is required.
+The dashboard fetches live data from the internet so an active connection is required. Data automatically refreshes every 5 minutes.
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- rerun the dashboard fetch logic every 5 minutes
- skip DOM updates when fetched data matches the cache
- document refresh interval in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a114273d4832fb9cfbe5dab0b6774