### PR TITLE
Implement DOM-based renderNews

### DIFF
--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -75,12 +75,19 @@ export function renderSnapshot(data) {
 export function renderNews(items) {
   const list = document.getElementById('news-list');
   if (!list) return;
-  list.innerHTML = '';
+  list.replaceChildren();
   items.forEach(it => {
     const li = document.createElement('li');
     li.className = 'list-group-item';
-    const date = new Date(it.date).toLocaleDateString();
-    li.innerHTML = `<a href="${it.link}" target="_blank">${it.title}</a> <small class="text-muted d-block">${date}</small>`;
+    const link = document.createElement('a');
+    link.textContent = it.title;
+    link.href = it.link;
+    link.target = '_blank';
+    const dateEl = document.createElement('small');
+    dateEl.className = 'text-muted d-block';
+    dateEl.textContent = new Date(it.date).toLocaleDateString();
+    li.appendChild(link);
+    li.appendChild(dateEl);
     list.appendChild(li);
   });
   setUpdated('news-updated');

--- a/src/__tests__/ui.test.js
+++ b/src/__tests__/ui.test.js
@@ -1,0 +1,23 @@
+import { renderNews } from '../../assets/js/ui.js';
+import { jest } from '@jest/globals';
+
+describe('renderNews', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<ul id="news-list"></ul>';
+  });
+
+  test('builds list items without using innerHTML', () => {
+    const spy = jest.spyOn(HTMLElement.prototype, 'innerHTML', 'set');
+    renderNews([{ title: 'Title', link: 'https://example.com', date: Date.now() }]);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+
+    const li = document.querySelector('#news-list li');
+    expect(li).not.toBeNull();
+    const a = li.querySelector('a');
+    const small = li.querySelector('small');
+    expect(a.textContent).toBe('Title');
+    expect(a.getAttribute('href')).toBe('https://example.com');
+    expect(small).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- replace innerHTML construction in `renderNews` with DOM API
- add unit test verifying list generation avoids `innerHTML`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a2ed74cfc832f8c3ed12f4a1530a8