### PR TITLE
Add manual reload buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ JavaScript code is organised in ES modules under `assets/js/`:
    # then visit http://localhost:8000/index.html
    ```
 
-The dashboard fetches live data from the internet so an active connection is required. Data automatically refreshes every 5 minutes.
+The dashboard fetches live data from the internet so an active connection is required. Data automatically refreshes every 5 minutes. Each section also has an **Actualizar** button to manually trigger a refresh at any time.
 
 ## Tests
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -39,152 +39,173 @@ function cacheGet(key) {
   }
 }
 
+function loadSnapshot(tick) {
+  const t = tick || initLoader(1);
+  return fetchSnapshot()
+    .then(data => {
+      const cached = cacheGet('snapshot');
+      if (!cached || !isEqual(cached.data, data)) {
+        renderSnapshot(data);
+      } else {
+        setUpdated('prices-updated');
+      }
+      cacheSet('snapshot', data);
+    })
+    .catch(err => {
+      console.log('snapshot error', err);
+      const cached = cacheGet('snapshot');
+      if (cached) {
+        renderSnapshot(cached.data);
+        setUpdated('prices-updated', cached.ts);
+      } else {
+        showError('prices-error', 'Datos no disponibles');
+      }
+    })
+    .finally(t);
+}
+
+function loadEthBtc(tick) {
+  const t = tick || initLoader(1);
+  return fetchEthBtc()
+    .then(d => {
+      const cached = cacheGet('ethbtc');
+      if (!cached || !isEqual(cached.data, d)) {
+        renderEthBtc(
+          document.getElementById('ethbtcChart'),
+          d.labels,
+          d.ratios
+        );
+      } else {
+        setUpdated('ethbtc-updated');
+      }
+      cacheSet('ethbtc', d);
+    })
+    .catch(err => {
+      console.log('ethbtc error', err);
+      const cached = cacheGet('ethbtc');
+      if (cached) {
+        renderEthBtc(
+          document.getElementById('ethbtcChart'),
+          cached.data.labels,
+          cached.data.ratios
+        );
+        setUpdated('ethbtc-updated', cached.ts);
+      } else {
+        showError('ethbtc-error', 'Datos no disponibles');
+      }
+    })
+    .finally(t);
+}
+
+function loadVolumes(tick) {
+  const t = tick || initLoader(1);
+  return fetchVolumes()
+    .then(d => {
+      const styleMap = {
+        RAY: { borderColor: '#0d6efd' },
+        CAKE: { borderColor: '#adb5bd', borderDash: [5, 5] },
+        CETUS: { borderColor: '#20c997', borderDash: [5, 2] },
+        ORCA: { borderColor: '#ffc107', borderDash: [2, 3] },
+        UNI: { borderColor: '#6610f2', borderDash: [3, 3] },
+      };
+
+      const sets = d.datasets.map(ds => {
+        const style = styleMap[ds.label] || {};
+        return {
+          label: ds.data ? ds.label : `${ds.label} (Datos no disponibles)`,
+          data: ds.data || [],
+          tension: 0.2,
+          fill: false,
+          ...style,
+        };
+      });
+
+      const payload = { labels: d.labels, sets };
+      const cached = cacheGet('volumes');
+      if (!cached || !isEqual(cached.data, payload)) {
+        renderVolumes(document.getElementById('volumeChart'), d.labels, sets);
+      } else {
+        setUpdated('volume-updated');
+      }
+      cacheSet('volumes', payload);
+    })
+    .catch(err => {
+      console.log('volumes error', err);
+      const cached = cacheGet('volumes');
+      if (cached) {
+        renderVolumes(
+          document.getElementById('volumeChart'),
+          cached.data.labels,
+          cached.data.sets
+        );
+        setUpdated('volume-updated', cached.ts);
+      } else {
+        showError('volume-error', 'Datos no disponibles');
+      }
+    })
+    .finally(t);
+}
+
+function loadGauge(tick) {
+  const t = tick || initLoader(1);
+  return fetchGauge()
+    .then(data => {
+      const cached = cacheGet('fng');
+      if (!cached || !isEqual(cached.data, data)) {
+        renderFngGauge(data);
+      } else {
+        setUpdated('fng-updated');
+      }
+      cacheSet('fng', data);
+    })
+    .catch(err => {
+      console.log('gauge error', err);
+      const cached = cacheGet('fng');
+      if (cached) {
+        renderFngGauge(cached.data);
+        setUpdated('fng-updated', cached.ts);
+      } else {
+        showError('fng-error', 'Datos no disponibles');
+      }
+    })
+    .finally(t);
+}
+
+function loadNews(tick) {
+  const t = tick || initLoader(1);
+  return fetchNews()
+    .then(data => {
+      const cached = cacheGet('news');
+      if (!cached || !isEqual(cached.data, data)) {
+        renderNews(data);
+      } else {
+        setUpdated('news-updated');
+      }
+      cacheSet('news', data);
+    })
+    .catch(err => {
+      console.log('news error', err);
+      const cached = cacheGet('news');
+      if (cached) {
+        renderNews(cached.data);
+        setUpdated('news-updated', cached.ts);
+      } else {
+        showError('news-error', 'Datos no disponibles');
+      }
+    })
+    .finally(t);
+}
+
 function start() {
   console.log('start');
   const tick = initLoader(5);
 
   Promise.allSettled([
-    fetchSnapshot()
-      .then(data => {
-        const cached = cacheGet('snapshot');
-        if (!cached || !isEqual(cached.data, data)) {
-          renderSnapshot(data);
-        } else {
-          setUpdated('prices-updated');
-        }
-        cacheSet('snapshot', data);
-      })
-      .catch(err => {
-        console.log('snapshot error', err);
-        const cached = cacheGet('snapshot');
-        if (cached) {
-          renderSnapshot(cached.data);
-          setUpdated('prices-updated', cached.ts);
-        } else {
-          showError('prices-error', 'Datos no disponibles');
-        }
-      })
-      .finally(tick),
-
-    fetchEthBtc()
-      .then(d => {
-        const cached = cacheGet('ethbtc');
-        if (!cached || !isEqual(cached.data, d)) {
-          renderEthBtc(
-            document.getElementById('ethbtcChart'),
-            d.labels,
-            d.ratios
-          );
-        } else {
-          setUpdated('ethbtc-updated');
-        }
-        cacheSet('ethbtc', d);
-      })
-      .catch(err => {
-        console.log('ethbtc error', err);
-        const cached = cacheGet('ethbtc');
-        if (cached) {
-          renderEthBtc(
-            document.getElementById('ethbtcChart'),
-            cached.data.labels,
-            cached.data.ratios
-          );
-          setUpdated('ethbtc-updated', cached.ts);
-        } else {
-          showError('ethbtc-error', 'Datos no disponibles');
-        }
-      })
-      .finally(tick),
-
-    fetchVolumes()
-      .then(d => {
-        const styleMap = {
-          RAY: { borderColor: '#0d6efd' },
-          CAKE: { borderColor: '#adb5bd', borderDash: [5, 5] },
-          CETUS: { borderColor: '#20c997', borderDash: [5, 2] },
-          ORCA: { borderColor: '#ffc107', borderDash: [2, 3] },
-          UNI: { borderColor: '#6610f2', borderDash: [3, 3] },
-        };
-
-        const sets = d.datasets.map(ds => {
-          const style = styleMap[ds.label] || {};
-          return {
-            label: ds.data ? ds.label : `${ds.label} (Datos no disponibles)`,
-            data: ds.data || [],
-            tension: 0.2,
-            fill: false,
-            ...style,
-          };
-        });
-
-        const payload = { labels: d.labels, sets };
-        const cached = cacheGet('volumes');
-        if (!cached || !isEqual(cached.data, payload)) {
-          renderVolumes(document.getElementById('volumeChart'), d.labels, sets);
-        } else {
-          setUpdated('volume-updated');
-        }
-        cacheSet('volumes', payload);
-      })
-      .catch(err => {
-        console.log('volumes error', err);
-        const cached = cacheGet('volumes');
-        if (cached) {
-          renderVolumes(
-            document.getElementById('volumeChart'),
-            cached.data.labels,
-            cached.data.sets
-          );
-          setUpdated('volume-updated', cached.ts);
-        } else {
-          showError('volume-error', 'Datos no disponibles');
-        }
-      })
-      .finally(tick),
-
-    fetchGauge()
-      .then(data => {
-        const cached = cacheGet('fng');
-        if (!cached || !isEqual(cached.data, data)) {
-          renderFngGauge(data);
-        } else {
-          setUpdated('fng-updated');
-        }
-        cacheSet('fng', data);
-      })
-      .catch(err => {
-        console.log('gauge error', err);
-        const cached = cacheGet('fng');
-        if (cached) {
-          renderFngGauge(cached.data);
-          setUpdated('fng-updated', cached.ts);
-        } else {
-          showError('fng-error', 'Datos no disponibles');
-        }
-      })
-      .finally(tick),
-
-    fetchNews()
-      .then(data => {
-        const cached = cacheGet('news');
-        if (!cached || !isEqual(cached.data, data)) {
-          renderNews(data);
-        } else {
-          setUpdated('news-updated');
-        }
-        cacheSet('news', data);
-      })
-      .catch(err => {
-        console.log('news error', err);
-        const cached = cacheGet('news');
-        if (cached) {
-          renderNews(cached.data);
-          setUpdated('news-updated', cached.ts);
-        } else {
-          showError('news-error', 'Datos no disponibles');
-        }
-      })
-      .finally(tick)
+    loadSnapshot(tick),
+    loadEthBtc(tick),
+    loadVolumes(tick),
+    loadGauge(tick),
+    loadNews(tick),
   ]);
 }
 
@@ -192,4 +213,54 @@ document.addEventListener('DOMContentLoaded', () => {
   console.log('DOMContentLoaded');
   start();
   setInterval(start, REFRESH_INTERVAL);
+
+  const btnPrices = document.getElementById('refresh-prices');
+  if (btnPrices) {
+    btnPrices.addEventListener('click', () => {
+      btnPrices.disabled = true;
+      loadSnapshot().finally(() => {
+        btnPrices.disabled = false;
+      });
+    });
+  }
+
+  const btnFng = document.getElementById('refresh-fng');
+  if (btnFng) {
+    btnFng.addEventListener('click', () => {
+      btnFng.disabled = true;
+      loadGauge().finally(() => {
+        btnFng.disabled = false;
+      });
+    });
+  }
+
+  const btnEthBtc = document.getElementById('refresh-ethbtc');
+  if (btnEthBtc) {
+    btnEthBtc.addEventListener('click', () => {
+      btnEthBtc.disabled = true;
+      loadEthBtc().finally(() => {
+        btnEthBtc.disabled = false;
+      });
+    });
+  }
+
+  const btnVolumes = document.getElementById('refresh-volumes');
+  if (btnVolumes) {
+    btnVolumes.addEventListener('click', () => {
+      btnVolumes.disabled = true;
+      loadVolumes().finally(() => {
+        btnVolumes.disabled = false;
+      });
+    });
+  }
+
+  const btnNews = document.getElementById('refresh-news');
+  if (btnNews) {
+    btnNews.addEventListener('click', () => {
+      btnNews.disabled = true;
+      loadNews().finally(() => {
+        btnNews.disabled = false;
+      });
+    });
+  }
 });

--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
             </div>
           </div>
           <small id="prices-updated" class="text-muted d-block mt-2"></small>
+          <button id="refresh-prices" class="btn btn-sm btn-outline-primary mt-2">Actualizar</button>
           <p id="prices-error" class="text-danger mt-1"></p>
         </div>
       </div>
@@ -59,12 +60,14 @@
         <canvas id="fngGauge" height="200" aria-label="Fear &amp; Greed" role="img"></canvas>
         <div id="fng-label" class="fw-bold"></div>
         <small id="fng-updated" class="text-muted mt-1"></small>
+        <button id="refresh-fng" class="btn btn-sm btn-outline-primary mt-2">Actualizar</button>
         <p id="fng-error" class="text-danger"></p>
       </div>
       <div class="col-md-4">
         <h2 class="h6">ETH/BTC</h2>
         <canvas id="ethbtcChart" height="250" aria-label="ETH/BTC" role="img"></canvas>
         <small id="ethbtc-updated" class="text-muted d-block mt-1"></small>
+        <button id="refresh-ethbtc" class="btn btn-sm btn-outline-primary mt-2">Actualizar</button>
         <p id="ethbtc-error" class="text-danger"></p>
       </div>
     </div>
@@ -74,12 +77,14 @@
         <h2 class="h6">Volúmenes DEX 30d</h2>
         <canvas id="volumeChart" height="300" aria-label="Volúmenes DEX" role="img"></canvas>
         <small id="volume-updated" class="text-muted d-block mt-1"></small>
+        <button id="refresh-volumes" class="btn btn-sm btn-outline-primary mt-2">Actualizar</button>
         <p id="volume-error" class="text-danger"></p>
       </div>
       <div class="col-lg-4">
         <h2 class="h6">Últimas noticias</h2>
         <ul id="news-list" class="list-group"></ul>
         <small id="news-updated" class="text-muted d-block mt-1"></small>
+        <button id="refresh-news" class="btn btn-sm btn-outline-primary mt-2">Actualizar</button>
         <p id="news-error" class="text-danger"></p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `Actualizar` buttons next to each data block
- expose data loaders and wire buttons in `main.js`
- document manual reloads in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a2ed5b62c832f8daf10102538fab2