### PR TITLE
Add offline fallback data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ JavaScript code is organised in ES modules under `assets/js/`:
    # then visit http://localhost:8000/index.html
    ```
 
-The dashboard fetches live data from the internet so an active connection is required. Data automatically refreshes every 5 minutes. Each section also has an **Actualizar** button to manually trigger a refresh at any time.
+The dashboard fetches live data from the internet, so an active connection is normally required. If the network is unavailable and no cached data exists, a small set of bundled example data is displayed so the charts remain visible. Data automatically refreshes every 5 minutes. Each section also has an **Actualizar** button to manually trigger a refresh at any time.
 
 ## Tests
 

--- a/assets/data/offlineData.js
+++ b/assets/data/offlineData.js
@@ -1,0 +1,25 @@
+export const OFFLINE_DATA = {
+  snapshot: {
+    bitcoin: { usd: 30000, usd_24h_change: 0 },
+    ethereum: { usd: 2000, usd_24h_change: 0 },
+    raydium: { usd: 0.5, usd_24h_change: 0 },
+  },
+  ethbtc: {
+    labels: ['2024-01-01'],
+    ratios: [0.053],
+  },
+  volumes: {
+    labels: ['2024-01-01'],
+    datasets: [
+      { label: 'RAY', data: [100000] },
+      { label: 'CAKE', data: [80000] },
+      { label: 'CETUS', data: [50000] },
+      { label: 'ORCA', data: [75000] },
+      { label: 'UNI', data: [120000] },
+    ],
+  },
+  fng: { value: 50, classification: 'Neutral' },
+  news: [
+    { title: 'Sin conexión: datos de ejemplo', link: '#', date: Date.now() },
+  ],
+};

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -14,6 +14,7 @@ import {
   renderFngGauge,
   setUpdated,
 } from './ui.js';
+import { OFFLINE_DATA } from '../data/offlineData.js';
 
 const REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
@@ -57,6 +58,9 @@ function loadSnapshot(tick) {
       if (cached) {
         renderSnapshot(cached.data);
         setUpdated('prices-updated', cached.ts);
+      } else if (OFFLINE_DATA.snapshot) {
+        renderSnapshot(OFFLINE_DATA.snapshot);
+        setUpdated('prices-updated');
       } else {
         showError('prices-error', 'Datos no disponibles');
       }
@@ -90,6 +94,13 @@ function loadEthBtc(tick) {
           cached.data.ratios
         );
         setUpdated('ethbtc-updated', cached.ts);
+      } else if (OFFLINE_DATA.ethbtc) {
+        renderEthBtc(
+          document.getElementById('ethbtcChart'),
+          OFFLINE_DATA.ethbtc.labels,
+          OFFLINE_DATA.ethbtc.ratios
+        );
+        setUpdated('ethbtc-updated');
       } else {
         showError('ethbtc-error', 'Datos no disponibles');
       }
@@ -139,6 +150,27 @@ function loadVolumes(tick) {
           cached.data.sets
         );
         setUpdated('volume-updated', cached.ts);
+      } else if (OFFLINE_DATA.volumes) {
+        const styleMap = {
+          RAY: { borderColor: '#0d6efd' },
+          CAKE: { borderColor: '#adb5bd', borderDash: [5, 5] },
+          CETUS: { borderColor: '#20c997', borderDash: [5, 2] },
+          ORCA: { borderColor: '#ffc107', borderDash: [2, 3] },
+          UNI: { borderColor: '#6610f2', borderDash: [3, 3] },
+        };
+        const sets = OFFLINE_DATA.volumes.datasets.map(ds => ({
+          label: ds.label,
+          data: ds.data,
+          tension: 0.2,
+          fill: false,
+          ...(styleMap[ds.label] || {}),
+        }));
+        renderVolumes(
+          document.getElementById('volumeChart'),
+          OFFLINE_DATA.volumes.labels,
+          sets
+        );
+        setUpdated('volume-updated');
       } else {
         showError('volume-error', 'Datos no disponibles');
       }
@@ -164,6 +196,9 @@ function loadGauge(tick) {
       if (cached) {
         renderFngGauge(cached.data);
         setUpdated('fng-updated', cached.ts);
+      } else if (OFFLINE_DATA.fng) {
+        renderFngGauge(OFFLINE_DATA.fng);
+        setUpdated('fng-updated');
       } else {
         showError('fng-error', 'Datos no disponibles');
       }
@@ -189,6 +224,9 @@ function loadNews(tick) {
       if (cached) {
         renderNews(cached.data);
         setUpdated('news-updated', cached.ts);
+      } else if (OFFLINE_DATA.news) {
+        renderNews(OFFLINE_DATA.news);
+        setUpdated('news-updated');
       } else {
         showError('news-error', 'Datos no disponibles');
       }


### PR DESCRIPTION
## Summary
- provide an offline data module with example values
- load fallback data when network and cache are unavailable
- mention offline support in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a306d316c832f8a829252a68edae7