### PR TITLE
Improve volume and F&G handling

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -82,21 +82,22 @@ export async function fetchVolumes() {
   );
 
   let labels = [];
-  const datasets = results.map((res, idx) => {
+  const datasets = [];
+  results.forEach((res, idx) => {
     const proto = protocols[idx];
-    if (res.status === 'fulfilled') {
+    if (res.status === 'fulfilled' && Array.isArray(res.value.total_volumes)) {
       if (!labels.length) {
         labels = res.value.total_volumes.map(v =>
           new Date(v[0]).toISOString().split('T')[0]
         );
       }
-      return {
+      datasets.push({
         label: proto.symbol,
         data: res.value.total_volumes.map(v => v[1]),
-      };
+      });
+    } else {
+      console.error(`Volúmenes ${proto.symbol}`, res.reason);
     }
-    console.error(`Volúmenes ${proto.symbol}`, res.reason);
-    return { label: proto.symbol, data: null };
   });
 
   return { labels, datasets };

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -123,16 +123,23 @@ function loadVolumes(tick) {
         '1INCH': { borderColor: '#d63384', borderDash: [4, 2] },
       };
 
-      const sets = d.datasets.map(ds => {
-        const style = styleMap[ds.label] || {};
-        return {
-          label: ds.data ? ds.label : `${ds.label} (Datos no disponibles)`,
-          data: ds.data || [],
-          tension: 0.2,
-          fill: false,
-          ...style,
-        };
-      });
+      const sets = d.datasets
+        .filter(ds => Array.isArray(ds.data) && ds.data.length)
+        .map(ds => {
+          const style = styleMap[ds.label] || {};
+          return {
+            label: ds.label,
+            data: ds.data,
+            tension: 0.2,
+            fill: false,
+            ...style,
+          };
+        });
+
+      if (!sets.length) {
+        showError('volume-error', 'Datos no disponibles');
+        return;
+      }
 
       const payload = { labels: d.labels, sets };
       const cached = cacheGet('volumes');
@@ -164,13 +171,19 @@ function loadVolumes(tick) {
           CRV: { borderColor: '#6f42c1', borderDash: [1, 2] },
           '1INCH': { borderColor: '#d63384', borderDash: [4, 2] },
         };
-        const sets = OFFLINE_DATA.volumes.datasets.map(ds => ({
-          label: ds.label,
-          data: ds.data,
-          tension: 0.2,
-          fill: false,
-          ...(styleMap[ds.label] || {}),
-        }));
+        const sets = OFFLINE_DATA.volumes.datasets
+          .filter(ds => Array.isArray(ds.data) && ds.data.length)
+          .map(ds => ({
+            label: ds.label,
+            data: ds.data,
+            tension: 0.2,
+            fill: false,
+            ...(styleMap[ds.label] || {}),
+          }));
+        if (!sets.length) {
+          showError('volume-error', 'Datos no disponibles');
+          return;
+        }
         renderVolumes(
           document.getElementById('volumeChart'),
           OFFLINE_DATA.volumes.labels,

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -102,11 +102,15 @@ export function renderFngGauge(data) {
   const canvas = document.getElementById('fngGauge');
   const label = document.getElementById('fng-label');
   if (!canvas || !label) return;
-  const { value, classification } =
-    typeof data === 'object' ? data : { value: data, classification: '' };
+  const { value: rawValue, classification = '' } =
+    typeof data === 'object' ? data : { value: data };
+  const value = Number(rawValue);
+  const valid = Number.isFinite(value);
+
+  const val = valid ? value : 0;
 
   if (fngChart) {
-    fngChart.data.datasets[0].value = value;
+    fngChart.data.datasets[0].value = val;
     fngChart.update();
   } else {
     fngChart = new Chart(canvas.getContext('2d'), {
@@ -114,7 +118,7 @@ export function renderFngGauge(data) {
       data: {
         datasets: [
           {
-            value,
+            value: val,
             data: [25, 25, 25, 25],
             minValue: 0,
             backgroundColor: ['#dc3545', '#fd7e14', '#ffc107', '#198754'],
@@ -128,6 +132,10 @@ export function renderFngGauge(data) {
       },
     });
   }
-  label.textContent = classification ? `${classification} (${value})` : value;
+  label.textContent = valid && classification
+    ? `${classification} (${value})`
+    : valid
+    ? String(value)
+    : 'N/A';
   setUpdated('fng-updated');
 }


### PR DESCRIPTION
## Summary
- handle missing volume data instead of plotting empty datasets
- filter datasets lacking data when rendering volume chart
- make Fear & Greed gauge robust when value missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a9d5ee4c4832f92db4a61bbf08758